### PR TITLE
Use cl-gensym instead of gensym

### DIFF
--- a/bui-utils.el
+++ b/bui-utils.el
@@ -459,7 +459,7 @@ by x."
     (if interact
 	(let* ((args  (eval `(call-interactively
 			      (lambda (&rest args) ,interact args))))
-	       (args2 (mapcar (lambda (x) (if (eq x '<>) (gensym) x))
+	       (args2 (mapcar (lambda (x) (if (eq x '<>) (cl-gensym) x))
 			      (cl-remove-if-not
                                (lambda (y) (memq y '(<> &rest)))
 			       args)))


### PR DESCRIPTION
This package still strives to support Emacs 24.3
but `gensym' wasn't added until Emacs 26.1.

Closes #10.