### PR TITLE
Fix docstrings

### DIFF
--- a/bui-core.el
+++ b/bui-core.el
@@ -114,14 +114,13 @@ See `bui-with-item' for details."
      ,@body))
 
 (defmacro bui-define-current-item-accessor (name)
-  "Define `bui-current-NAME' function to access NAME
-element of `bui-item' structure.
+  "Define accessor for `bui-item's NAME field.
 NAME should be a symbol."
   (let* ((name-str (symbol-name name))
          (accessor (intern (concat "bui-item-" name-str)))
          (fun-name (intern (concat "bui-current-" name-str)))
          (doc      (format "\
-Return '%s' of the current BUI buffer.
+Return \\+`%s' of the current BUI buffer.
 See `bui-item' for details."
                            name-str)))
     `(defun ,fun-name ()
@@ -141,22 +140,22 @@ See `bui-define-current-item-accessor' for details."
  entries entry-type buffer-type args)
 
 (defmacro bui-define-current-args-accessor (n prefix name)
-  "Define `PREFIX-NAME' function to access Nth element of 'args'
-field of `bui-item' structure.
-PREFIX and NAME should be symbols."
+  "Define PREFIX-NAME accessor for Nth element of \\+`args' field of
+`bui-item' structure.
+PREFIX and NAME should be symbols"
   (let* ((prefix-str (symbol-name prefix))
          (name-str   (symbol-name name))
          (fun-name   (intern (concat prefix-str "-" name-str)))
          (doc        (format "\
-Return '%s' of the current buffer.
-'%s' is the element number %d in 'args' field of `bui-item'."
+Return \\+`%s' of the current buffer.
+\\+`%s' is the element number %d in \\+`args' field of `bui-item'."
                              name-str name-str n)))
     `(defun ,fun-name ()
        ,doc
        (nth ,n (bui-current-args)))))
 
 (defmacro bui-define-current-args-accessors (prefix &rest names)
-  "Define `PREFIX-NAME' functions for NAMES.
+  "Define PREFIX-NAME functions for NAMES.
 See `bui-define-current-args-accessor' for details."
   (declare (indent 1))
   `(progn
@@ -186,7 +185,7 @@ See `bui-hint' for details.")
   '(bui-filter-by-regexp bui-filter-by-sexp)
   "List of available filter predicates.
 These predicates are used as completions for
-'\\[bui-enable-filter]' command to hide entries. See
+'\\[bui-enable-filter]' command to hide entries.  See
 `bui-active-filter-predicates' for details."
   :type '(repeat function)
   :group 'bui)
@@ -234,9 +233,8 @@ Interactively, prompt for PARAM and REGEXP."
 Evaluate SEXP and return its value.
 SEXP can use the ENTRY's parameters as symbols, e.g.:
 
-  '(or (string-match-p \"foo\" name)
-       (string-match-p \"bar\" synopsis))
-"
+  \\='(or (string-match-p \"foo\" name)
+       (string-match-p \"bar\" synopsis))"
   (interactive (list '<> (read--expression "sexp: ")))
   (dolist (param (bui-current-params))
     (setq sexp (cl-subst (bui-assq-value entry param)
@@ -471,7 +469,7 @@ interface.")
   "Return symbol suffix from symbol specification.")
 
 (defalias 'bui-symbol-specification-generate #'cl-third
-  "Return 'generate' value from symbol specification.")
+  "Return \\+`generate' value from symbol specification.")
 
 (defun bui-symbol-generate? (generate &optional reduced?)
   "Return non-nil if a symbol should be generated.
@@ -533,7 +531,7 @@ SPECIFICATIONS should have a form of `bui-symbol-specifications'."
 
 (defun bui-get-entries (entry-type buffer-type &optional args)
   "Return ENTRY-TYPE entries.
-Call an appropriate 'get-entries' function using ARGS as its arguments."
+Call an appropriate \\+`get-entries' function using ARGS as its arguments."
   (apply (bui-symbol-value entry-type buffer-type 'get-entries-function)
          args))
 
@@ -640,11 +638,11 @@ Use '\\[bui-disable-filters]' to remove filters")))))
   "Set up the current buffer for displaying BUFFER-ITEM.
 HISTORY should be one of the following:
 
-  `nil' or `add' - add it to history,
+  nil or \\+`add' - add it to history,
 
-  `no' - do not save BUFFER-ITEM in history,
+  \\+`no' - do not save BUFFER-ITEM in history,
 
-  `replace' - replace the current history item."
+  \\+`replace' - replace the current history item."
   (bui-with-item buffer-item
     (when %entries
       ;; At first, set buffer item so that its value can be used by the

--- a/bui-info.el
+++ b/bui-info.el
@@ -132,18 +132,18 @@ This string is used by `bui-info-insert-value-format'."
     (:ignore-void-values ignore-void-values t)
     (:multiline-prefix multiline-prefix t)
     (:title-format param-title-format t))
-  "Specifications for generating 'info' variables.
+  "Specifications for generating \\+`info' variables.
 See `bui-symbol-specifications' for details.")
 
 
 ;;; Wrappers for 'info' variables
 
 (defun bui-info-symbol (entry-type symbol)
-  "Return symbol for ENTRY-TYPE and 'info' buffer type."
+  "Return symbol for ENTRY-TYPE and \\+`info' buffer type."
   (bui-symbol entry-type 'info symbol))
 
 (defun bui-info-symbol-value (entry-type symbol)
-  "Return SYMBOL's value for ENTRY-TYPE and 'info' buffer type."
+  "Return SYMBOL's value for ENTRY-TYPE and \\+`info' buffer type."
   (bui-symbol-value entry-type 'info symbol))
 
 (defun bui-info-param-title (entry-type param)
@@ -151,7 +151,7 @@ See `bui-symbol-specifications' for details.")
   (bui-param-title entry-type 'info param))
 
 (defun bui-info-format (entry-type)
-  "Return 'info' format for ENTRY-TYPE."
+  "Return \\+`info' format for ENTRY-TYPE."
   (bui-info-symbol-value entry-type 'format))
 
 (defun bui-info-displayed-params (entry-type)
@@ -355,11 +355,11 @@ See `bui-get-time-string' for the meaning of TIME."
   "Keymap for `bui-info-mode' buffers.")
 
 (define-derived-mode bui-info-mode special-mode "BUI-Info"
-  "Parent mode for displaying data in 'info' form."
+  "Parent mode for displaying data in \\+`info' form."
   (bui-info-initialize))
 
 (defun bui-info-initialize ()
-  "Set up the current 'info' buffer."
+  "Set up the current \\+`info' buffer."
   ;; Without this, syntactic fontification is performed, and it may
   ;; break highlighting.  For example, if there is a single "
   ;; (double-quote) character, the default syntactic fontification

--- a/bui-list.el
+++ b/bui-list.el
@@ -53,7 +53,7 @@ For the meaning of WIDTH, SORT and PROPS, see
 (put 'bui-list-format 'permanent-local t)
 
 (defcustom bui-list-sort-key nil
-  "Default sort key for 'list' buffer.
+  "Default sort key for \\+`list' buffer.
 Should be nil (no sort) or have a form:
 
   (PARAM . FLIP)
@@ -66,13 +66,13 @@ FLIP, see `tabulated-list-sort-key'."
 (put 'bui-list-sort-key 'permanent-local t)
 
 (defvar bui-list-additional-marks nil
-  "Alist of additional marks for 'list' buffer.
+  "Alist of additional marks for \\+`list' buffer.
 Marks from this list are used along with `bui-list-default-marks'.")
 (put 'bui-list-additional-marks 'permanent-local t)
 
 (defcustom bui-list-show-single nil
   "If non-nil, list an entry even if it is the only matching result.
-If nil, show a single entry in the 'info' buffer instead."
+If nil, show a single entry in the \\+`info' buffer instead."
   :type 'boolean
   :group 'bui-list)
 (put 'bui-list-show-single 'permanent-local t)
@@ -89,8 +89,8 @@ you will be prompted for confirmation.  See also
 (defvar bui-list-describe-function nil
   "Function used by `bui-list-describe'.
 It is applied to the entries IDs as the rest arguments.
-If nil, 'describing' is not performed (it usually means that
-'info' interface is not defined).")
+If nil, \\+`describing' is not performed (it usually means that
+\\+`info' interface is not defined).")
 (put 'bui-list-describe-function 'permanent-local t)
 
 (defconst bui-list-symbol-specifications
@@ -100,7 +100,7 @@ If nil, 'describing' is not performed (it usually means that
     (:list-single?      show-single t)
     (:marks             additional-marks)
     (:sort-key          sort-key t))
-  "Specifications for generating 'list' variables.
+  "Specifications for generating \\+`list' variables.
 See `bui-symbol-specifications' for details.")
 
 
@@ -108,7 +108,7 @@ See `bui-symbol-specifications' for details.")
 
 (defun bui-list-describe (&rest mark-names)
   "Describe entries marked with MARK-NAMES.
-'Describe' means display entries in 'info' buffer.
+\\+`Describe' means display entries in \\+`info' buffer.
 If no entries are marked, describe the current entry.
 
 Available MARK-NAMES are symbols from `bui-list-marks'.
@@ -132,11 +132,11 @@ prefix argument, describe entries marked with any mark."
 ;;; Wrappers for 'list' variables
 
 (defun bui-list-symbol (entry-type symbol)
-  "Return symbol for ENTRY-TYPE and 'list' buffer type."
+  "Return symbol for ENTRY-TYPE and \\+`list' buffer type."
   (bui-symbol entry-type 'list symbol))
 
 (defun bui-list-symbol-value (entry-type symbol)
-  "Return SYMBOL's value for ENTRY-TYPE and 'list' buffer type."
+  "Return SYMBOL's value for ENTRY-TYPE and \\+`list' buffer type."
   (bui-symbol-value entry-type 'list symbol))
 
 (defun bui-list-param-title (entry-type param)
@@ -241,7 +241,7 @@ Parameters are taken from ENTRY-TYPE ENTRY."
 ;;; Displaying entries
 
 (defun bui-list-get-display-entries (entry-type &rest args)
-  "Search for entries and show them in a 'list' buffer preferably."
+  "Search for entries and show them in a \\+`list' buffer preferably."
   (let ((entries (bui-get-entries entry-type 'list args)))
     (if (or (null entries)      ; = 0
             (cdr entries)       ; > 1
@@ -497,21 +497,21 @@ Same as `tabulated-list-sort', but also restore marks after sorting."
   '(("\\[bui-list-mark]") " mark; "
     ("\\[bui-list-unmark]") " unmark; "
     ("\\[bui-list-unmark-backward]") " unmark backward;\n")
-  "Hint with 'mark' keys for 'list' buffer.
+  "Hint with \\+`mark' keys for \\+`list' buffer.
 See `bui-hint' for details.")
 
 (defvar bui-list-sort-hint
   '(("\\[bui-list-sort]") " sort by column;\n")
-  "Hint with 'sort' keys for 'list' buffer.
+  "Hint with \\+`sort' keys for \\+`list' buffer.
 See `bui-hint' for details.")
 
 (defvar bui-list-info-hint
   '(("\\[bui-list-describe]") " show 'info' buffer;\n")
-  "Hint for 'list' buffer used only when 'info' interface is defined.
+  "Hint for \\+`list' buffer used only when \\+`info' interface is defined.
 See `bui-hint' for details.")
 
 (defun bui-list-hint ()
-  "Return hint structure for the current 'list' buffer."
+  "Return hint structure for the current \\+`list' buffer."
   (bui-format-hints
    bui-list-mark-hint
    (and (bui-interface-defined? (bui-current-entry-type) 'info)
@@ -519,11 +519,11 @@ See `bui-hint' for details.")
    bui-list-sort-hint))
 
 (define-derived-mode bui-list-mode tabulated-list-mode "BUI-List"
-  "Parent mode for displaying data in 'list' form."
+  "Parent mode for displaying data in \\+`list' form."
   (bui-list-initialize))
 
 (defun bui-list-initialize ()
-  "Set up the current 'list' buffer."
+  "Set up the current \\+`list' buffer."
   (setq tabulated-list-padding  2
         tabulated-list-format   (bui-list-tabulated-format)
         tabulated-list-sort-key (bui-list-tabulated-sort-key))

--- a/bui-utils.el
+++ b/bui-utils.el
@@ -284,7 +284,7 @@ be bound to `%foreign-args' variable.
 
 Example:
 
-  (bui-plist-let '(:two 8 :great ! :bui is)
+  (bui-plist-let \\='(:two 8 :great ! :bui is)
       ((one :one 1)
        (two :two 2)
        (foo :smth))

--- a/bui.el
+++ b/bui.el
@@ -166,7 +166,7 @@ is nil, along with the mentioned groups and variables,
                  '(,mode-name (bui-active-filter-predicates
                                bui-filter-mode-line-string))
                  ,(format "\
-Major mode for displaying '%S' entries in '%S' buffer.
+Major mode for displaying \\+`%S' entries in \\+`%S' buffer.
 
 \\{%S}"
                           entry-type buffer-type mode-map)


### PR DESCRIPTION
Emacs aren't so happy about your docstrings so I took the liberty of changing them.
1. Rephrased a couple of docstrings
2. Where appropriate I escaped apostrophe: `\\='`
3. Replaced double apostrophes with grave accent and apostrophe and quoted them where needed
4. Removed apostrophes around function arguments, nil, t